### PR TITLE
RANCHER-2321: Align pom.xml with template pattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,16 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <name>app-marc-migrations</name>
+  <name>${project.name}</name>
   <artifactId>app-marc-migrations</artifactId>
   <groupId>org.folio</groupId>
   <description>MARC Migrations Application</description>
   <version>2.2.0-SNAPSHOT</version>
 
   <properties>
+    <project.name>app-marc-migrations</project.name>
     <folio-application-generator.version>1.2.0-SNAPSHOT</folio-application-generator.version>
+    <templatePath>${basedir}/${project.name}.template.json</templatePath>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -28,7 +30,7 @@
           </execution>
         </executions>
         <configuration>
-          <templatePath>${basedir}/app-marc-migrations.template.json</templatePath>
+          <templatePath>${templatePath}</templatePath>
           <moduleRegistries>
             <registry>
               <type>okapi</type>
@@ -80,9 +82,9 @@
   </pluginRepositories>
 
   <scm>
-    <url>https://https://github.com/folio-org/app-platform-minimal</url>
-    <connection>scm:git:git://github.com:folio-org/app-platform-minimal.git</connection>
-    <developerConnection>scm:git:git@github.com:folio-org/app-platform-minimal.git</developerConnection>
+    <url>https://github.com/folio-org/${project.name}</url>
+    <connection>scm:git:git://github.com:folio-org/${project.name}.git</connection>
+    <developerConnection>scm:git:git@github.com:folio-org/${project.name}.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 </project>


### PR DESCRIPTION
Aligns app-marc-migrations pom.xml with template pattern for Maven parameter passing.

**Changes:**
- Add project.name and templatePath properties  
- Update configuration to use ${templatePath} and ${project.name}
- Fix SCM URLs and double https:// protocol

**Benefits:**
- Enables Maven parameter overriding
- Standardizes naming across repositories
- Supports automated workflows

**Related:** RANCHER-2321