### PR TITLE
MODDATAIMP-1225 - Add dependency on app-data-import

### DIFF
--- a/app-marc-migrations.template.json
+++ b/app-marc-migrations.template.json
@@ -19,6 +19,10 @@
     {
       "name": "app-inventory",
       "version": "^1.0.0-SNAPSHOT"
+    },
+    {
+      "name": "app-data-import",
+      "version": "^1.0.0-SNAPSHOT"
     }
   ],
   "modules": [

--- a/application.template.json
+++ b/application.template.json
@@ -23,6 +23,11 @@
       "name": "app-inventory",
       "version": "^1.0.0-SNAPSHOT",
       "preRelease": "only"
+    },
+    {
+      "name": "app-data-import",
+      "version": "^1.0.0-SNAPSHOT",
+      "preRelease": "only"
     }
   ],
   "modules": [


### PR DESCRIPTION
## Purpose
The mod-source-record-manager module is being extracted from the app-platform-complete to the app-data-import application. Since mod-marc-migration depends on mod-source-record-manager interface, a dependency on app-data-import should be added.


## Learning
[MODDATAIMP-1225](https://issues.folio.org/browse/MODDATAIMP-1225)